### PR TITLE
Update adding_database.asciidoc

### DIFF
--- a/common/adding_database.asciidoc
+++ b/common/adding_database.asciidoc
@@ -26,7 +26,7 @@ In the terminal, please go to the location on your machine where you cloned the 
 [source, bash]
 ----
 
- > oc new-app -p CCP_IMAGE_TAG=centos7-9.5-1.2.2 .\master-slave-rc-dc-slaves-only.json
+ > oc new-app -p CCP_IMAGE_TAG=1.2.1 .\master-slave-rc-dc-slaves-only.json
 
 ----
 


### PR DESCRIPTION
this PR makes the 'oc new-app' command refer to the 1.2.1 version of the crunchydata/crunchy-postgres and collect containers.
